### PR TITLE
Add UseForEmptyUserAgents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ Configure middleware
 | -------- | ------- | ----------- |
 | `ProxyUrl` | *Required* | URL of your running Rendertron proxy service. |
 | `UserAgents` | A set of known bots that benefit from pre-rendering. ("W3C_Validator", "baiduspider", "bingbot", "embedly", "facebookexternalhit", "linkedinbo", "outbrain", "pinterest", "quora link preview", "rogerbo", "showyoubot", "slackbot", "twitterbot", "vkShare") | Part of requests by User-Agent header. |
-| `UseForEmptyUserAgents` | `false` | Pre-rendering for empty User-Agent |
+| `UseForEmptyUserAgents` | `true` | Pre-rendering for empty User-Agent |
 | `InjectShadyDom` | `false` | Force the web components polyfills to be loaded. [Read more.](https://github.com/GoogleChrome/rendertron#web-components) |
 | `Timeout` | `TimeSpan.FromSeconds(11)` | Millisecond timeout for the proxy request to Rendertron. If exceeded, the standard response is served (i.e. `next()` is called). See also the [Rendertron timeout.](https://github.com/GoogleChrome/rendertron#rendering-budget-timeout) |

--- a/src/AspNetCore.Rendertron/RendertronMiddleware.cs
+++ b/src/AspNetCore.Rendertron/RendertronMiddleware.cs
@@ -57,7 +57,7 @@ namespace AspNetCore.Rendertron
 
         private bool IsNeedRender(string userAgent, CancellationToken cancellationToken)
         {
-            return _options.UserAgents.Any(x =>
+            return (_options.UseForEmptryUserAgents && string.IsNullOrEmptry(userAgent)) ||  _options.UserAgents.Any(x =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return userAgent.Contains(x.ToLowerInvariant());

--- a/src/AspNetCore.Rendertron/RendertronMiddlewareOptions.cs
+++ b/src/AspNetCore.Rendertron/RendertronMiddlewareOptions.cs
@@ -29,5 +29,6 @@ namespace AspNetCore.Rendertron
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(11);
         public bool InjectShadyDom { get; set; }
         public TimeSpan HttpCacheMaxAge { get; set; } = TimeSpan.Zero;
+        public bool UseForEmptyUserAgents { get; set; }
     }
 }


### PR DESCRIPTION
This addresses #3 by defining the proper option and adding additional logic to the `IsNeedRender` method.