### PR TITLE
Add Googlebot to default list

### DIFF
--- a/src/AspNetCore.Rendertron/RendertronMiddlewareOptions.cs
+++ b/src/AspNetCore.Rendertron/RendertronMiddlewareOptions.cs
@@ -21,7 +21,8 @@ namespace AspNetCore.Rendertron
             "showyoubot",
             "slackbot",
             "twitterbot",
-            "vkShare"
+            "vkShare",
+            "googlebot"
         };
 
         public string ProxyUrl { get; set; }


### PR DESCRIPTION
A lot of use cases for pre-render solutions aren't just for social networks, but also for improving indexing for Google, Bing, etc. While google can manage on their own without pre-render I've been seeing more people suggesting to use tools like this to improve the efficiency at which their content can be indexed.