### PR TITLE
Off by one in replacement

### DIFF
--- a/src/AspNetCore.Rendertron/StringExtensions.cs
+++ b/src/AspNetCore.Rendertron/StringExtensions.cs
@@ -8,7 +8,7 @@ namespace AspNetCore.Rendertron
             var startIndex = source.IndexOf(oldValueStart);
             var endIndex = source.IndexOf(oldValueEnd, startIndex);
             return source
-                .Remove(startIndex, endIndex - startIndex)
+                .Remove(startIndex, endIndex - startIndex + 1)
                 .Insert(startIndex, newValue);
         }
     }


### PR DESCRIPTION
String replacement does not remove last character, thus an excess closing angle bracket is left in the string after replacement.